### PR TITLE
Replace by https://github.com/SalGnt/Sublime-VimL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,9 @@
-# vimscript-sublime
+# vimscript-sublime (deprecated)
 Vim Script syntax highlighting for Sublime Text 3
 
 I'm utterly amazed that I couldn't find Vimscript syntax highlighting for Sublime Text 3 already.
 
 So ~~I made~~ I'm making it myself.
 
+# Please, use https://github.com/evandroforks/VimL instead of this one
 
-## Installation
-
-### By Package Control
-
-1. Download & Install **`Sublime Text 3`** (https://www.sublimetext.com/3)
-1. Go to the menu **`Tools -> Install Package Control`**, then,
-   wait few seconds until the installation finishes up
-1. Now,
-   Go to the menu **`Preferences -> Package Control`**
-1. Type **`Add Channel`** on the opened quick panel and press <kbd>Enter</kbd>
-1. Then,
-   input the following address and press <kbd>Enter</kbd>
-   ```
-   https://raw.githubusercontent.com/evandrocoan/StudioChannel/master/channel.json
-   ```
-1. Go to the menu **`Tools -> Command Palette...
-   (Ctrl+Shift+P)`**
-1. Type **`Preferences:
-   Package Control Settings – User`** on the opened quick panel and press <kbd>Enter</kbd>
-1. Then,
-   find the following setting on your **`Package Control.sublime-settings`** file:
-   ```js
-       "channels":
-       [
-           "https://packagecontrol.io/channel_v3.json",
-           "https://raw.githubusercontent.com/evandrocoan/StudioChannel/master/channel.json",
-       ],
-   ```
-1. And,
-   change it to the following, i.e.,
-   put the **`https://raw.githubusercontent...`** line as first:
-   ```js
-       "channels":
-       [
-           "https://raw.githubusercontent.com/evandrocoan/StudioChannel/master/channel.json",
-           "https://packagecontrol.io/channel_v3.json",
-       ],
-   ```
-   * The **`https://raw.githubusercontent...`** line must to be added before the **`https://packagecontrol.io...`** one, otherwise,
-     you will not install this forked version of the package,
-     but the original available on the Package Control default channel **`https://packagecontrol.io...`**
-1. Now,
-   go to the menu **`Preferences -> Package Control`**
-1. Type **`Install Package`** on the opened quick panel and press <kbd>Enter</kbd>
-1. Then,
-   search for **`VimScript`** and press <kbd>Enter</kbd>
-
-See also:
-1. [ITE - Integrated Toolset Environment](https://github.com/evandrocoan/ITE)
-1. [Package control docs](https://packagecontrol.io/docs/usage) for details.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,55 @@ Vim Script syntax highlighting for Sublime Text 3
 I'm utterly amazed that I couldn't find Vimscript syntax highlighting for Sublime Text 3 already.
 
 So ~~I made~~ I'm making it myself.
+
+
+## Installation
+
+### By Package Control
+
+1. Download & Install **`Sublime Text 3`** (https://www.sublimetext.com/3)
+1. Go to the menu **`Tools -> Install Package Control`**, then,
+   wait few seconds until the installation finishes up
+1. Now,
+   Go to the menu **`Preferences -> Package Control`**
+1. Type **`Add Channel`** on the opened quick panel and press <kbd>Enter</kbd>
+1. Then,
+   input the following address and press <kbd>Enter</kbd>
+   ```
+   https://raw.githubusercontent.com/evandrocoan/StudioChannel/master/channel.json
+   ```
+1. Go to the menu **`Tools -> Command Palette...
+   (Ctrl+Shift+P)`**
+1. Type **`Preferences:
+   Package Control Settings – User`** on the opened quick panel and press <kbd>Enter</kbd>
+1. Then,
+   find the following setting on your **`Package Control.sublime-settings`** file:
+   ```js
+       "channels":
+       [
+           "https://packagecontrol.io/channel_v3.json",
+           "https://raw.githubusercontent.com/evandrocoan/StudioChannel/master/channel.json",
+       ],
+   ```
+1. And,
+   change it to the following, i.e.,
+   put the **`https://raw.githubusercontent...`** line as first:
+   ```js
+       "channels":
+       [
+           "https://raw.githubusercontent.com/evandrocoan/StudioChannel/master/channel.json",
+           "https://packagecontrol.io/channel_v3.json",
+       ],
+   ```
+   * The **`https://raw.githubusercontent...`** line must to be added before the **`https://packagecontrol.io...`** one, otherwise,
+     you will not install this forked version of the package,
+     but the original available on the Package Control default channel **`https://packagecontrol.io...`**
+1. Now,
+   go to the menu **`Preferences -> Package Control`**
+1. Type **`Install Package`** on the opened quick panel and press <kbd>Enter</kbd>
+1. Then,
+   search for **`VimScript`** and press <kbd>Enter</kbd>
+
+See also:
+1. [ITE - Integrated Toolset Environment](https://github.com/evandrocoan/ITE)
+1. [Package control docs](https://packagecontrol.io/docs/usage) for details.

--- a/vimscript.sublime-syntax
+++ b/vimscript.sublime-syntax
@@ -3,7 +3,10 @@
 # See http://www.sublimetext.com/docs/3/syntax.html
 name: Vimscript
 scope: source.vimscript
-file_extensions: [vim]
+file_extensions:
+  - vim
+  - vimrc
+  - .vimrc
 
 contexts:
   # The prototype context is prepended to all contexts but those setting
@@ -24,27 +27,33 @@ contexts:
     # strings in YAML. When using single quoted strings, only single quotes
     # need to be escaped: this is done by using two single quotes next to each
     # other.
-    - match: '\b(if|else|for|while)\b'
-      scope: keyword.control.example-c
+    - match: '\b(?:end)?(if|else|for|while|end|return|try)\b'
+      scope: keyword.control.vim
+
+    - match: '\b(?:end)?(function)\b'
+      scope: support.function.definition.vim
+
+    - match: '\b(let)\b'
+      scope: storage.type.function.vim
 
   numbers:
     - match: '\b(-)?[0-9.]+\b'
-      scope: constant.numeric.example-c
+      scope: constant.numeric.vim
 
   strings:
     # Strings begin and end with quotes, and use backslashes as an escape
     # character.
     - match: '"'
-      scope: punctuation.definition.string.begin.example-c
+      scope: punctuation.definition.string.begin.vim
       push: inside_string
 
   inside_string:
     - meta_include_prototype: false
-    - meta_scope: string.quoted.double.example-c
+    - meta_scope: string.quoted.double.vim
     - match: '\.'
-      scope: constant.character.escape.example-c
+      scope: constant.character.escape.vim
     - match: '"'
-      scope: punctuation.definition.string.end.example-c
+      scope: punctuation.definition.string.end.vim
       pop: true
 
   comments:
@@ -53,6 +62,6 @@ contexts:
       scope: punctuation.definition.comment.vimscript
       push:
         # This is an anonymous context push for brevity.
-        - meta_scope: comment.line.double-slash.example-c
+        - meta_scope: comment.line.double-slash.vim
         - match: $\n?
           pop: true

--- a/vimscript.sublime-syntax
+++ b/vimscript.sublime-syntax
@@ -31,7 +31,7 @@ contexts:
       scope: keyword.control.vim
 
     - match: '\b(?:end)?(function)\b'
-      scope: support.function.definition.vim
+      scope:  entity.name.context.vim
 
     - match: '\b(let)\b'
       scope: storage.type.function.vim


### PR DESCRIPTION
I think https://github.com/SalGnt/Sublime-VimL is more complete than this one, then, may be add a deprecated warning at README.md?

https://github.com/mattbanks/dotfiles-syntax-highlighting-st2/issues/8